### PR TITLE
Fix dirs for KITTI-full

### DIFF
--- a/package/dataset-KITTI-full/.cm/meta.json
+++ b/package/dataset-KITTI-full/.cm/meta.json
@@ -6,8 +6,8 @@
     "no_ver_in_suggested_path": "yes",
     "force_ask_path":"yes",
     "install_env": {
-      "IMAGE_DIR": "image_2",
-      "LABELS_DIR": "labels_2",
+      "IMAGE_DIR": "training/image_2",
+      "LABELS_DIR": "training/label_2",
       "KITTI_IMAGES_ARCHIVE": "data_object_image_2.zip",
       "KITTI_LABELS_ARCHIVE": "data_object_label_2.zip",
       "KITTI_IMAGES_URL":"http://kitti.is.tue.mpg.de/kitti/data_object_image_2.zip",


### PR DESCRIPTION
Hi,

This PR incorrectly specified IMAGE and LABEL dirs for `dataset-KITTI-full`.