### PR TITLE
TF_CC 1.3 prebuilt for 32-bit Linux

### DIFF
--- a/package/lib-tensorflow_cc-prebuilt-1.3.0-aarch64/.cm/meta.json
+++ b/package/lib-tensorflow_cc-prebuilt-1.3.0-aarch64/.cm/meta.json
@@ -4,7 +4,7 @@
     "extra_dir": "", 
     "force_ask_path": "yes", 
     "install_env": {
-      "PACKAGE_NAME_64_BIT": "tf_cc-1.3.0-install.tar.gz",
+      "PACKAGE_NAME_64_BIT": "tf_cc-1.3.0-install-aarch64-linux-64.tar.gz",
       "PACKAGE_NAME_32_BIT": "tf_cc-1.3.0-install-aarch64-linux-32.tar.gz",
       "PACKAGE_SKIP_CLEAN_INSTALL": "YES", 
       "PACKAGE_SKIP_LINUX_MAKE": "YES", 

--- a/package/lib-tensorflow_cc-prebuilt-1.3.0-aarch64/.cm/meta.json
+++ b/package/lib-tensorflow_cc-prebuilt-1.3.0-aarch64/.cm/meta.json
@@ -4,8 +4,8 @@
     "extra_dir": "", 
     "force_ask_path": "yes", 
     "install_env": {
-      "PACKAGE_NAME": "tf_cc-1.3.0-install.tar.gz", 
-      "PACKAGE_NAME1": "tf_cc-1.3.0-install.tar.gz", 
+      "PACKAGE_NAME_64_BIT": "tf_cc-1.3.0-install.tar.gz",
+      "PACKAGE_NAME_32_BIT": "tf_cc-1.3.0-install-aarch64-linux-32.tar.gz",
       "PACKAGE_SKIP_CLEAN_INSTALL": "YES", 
       "PACKAGE_SKIP_LINUX_MAKE": "YES", 
       "PACKAGE_UNTAR": "YES", 
@@ -35,6 +35,7 @@
     "tensorflow", 
     "tensorflow_cc", 
     "prebuilt",
+    "aarch64",
     "vsrc",
     "v1.3.0",
     "v1.3",

--- a/package/lib-tensorflow_cc-prebuilt-1.3.0-aarch64/scripts.linux/pre-download.sh
+++ b/package/lib-tensorflow_cc-prebuilt-1.3.0-aarch64/scripts.linux/pre-download.sh
@@ -14,3 +14,17 @@ if [ "$ARCH" != "aarch64" ]; then
     echo "Unsupported architecture. Only aarch64 is supported for now"
     exit 1
 fi
+
+ELF32=`file -L /sbin/init | grep -o "ELF 32-bit"`
+ELF64=`file -L /sbin/init | grep -o "ELF 64-bit"`
+
+if [ -n "$ELF32" ]; then
+    export PACKAGE_NAME="$PACKAGE_NAME_32_BIT"
+elif [ -n "$ELF64" ]; then
+    export PACKAGE_NAME="$PACKAGE_NAME_64_BIT"
+else
+    echo "Unsupported executable format. Only ELF 32-bit and ELF 64-bit are supported for now"
+    exit 1
+fi
+
+export PACKAGE_NAME1="$PACKAGE_NAME"


### PR DESCRIPTION
This PR modifies the lib-tensorflow_cc-prebuilt-1.3.0-aarch64 package so that it downloads 32-bit archive on a 32-bit Linux, and 64-bit archive on a 64-bit Linux. Thus, the package may be used on Firefly.