### PR TITLE
FIX tf api compatibility problem

### DIFF
--- a/dataset/tf-benchmark-alexnet/benchmark-alexnet.py
+++ b/dataset/tf-benchmark-alexnet/benchmark-alexnet.py
@@ -209,8 +209,10 @@ def run_benchmark(openme):
     pool5, parameters = inference(images)
 
     # Build an initialization operation.
-    init = tf.global_variables_initializer()
-
+    if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+      init = tf.initialize_all_variables()
+    else: # For tf version >= 0.12.0
+      init = tf.global_variables_initializer()
     # Start running operations on the Graph.
     config = tf.ConfigProto()
     config.gpu_options.allocator_type = 'BFC'

--- a/dataset/tf-benchmark-alexnet/benchmark-alexnet.py
+++ b/dataset/tf-benchmark-alexnet/benchmark-alexnet.py
@@ -209,7 +209,9 @@ def run_benchmark(openme):
     pool5, parameters = inference(images)
 
     # Build an initialization operation.
-    if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+    tf_major_ver = int(tf.__version__.split(".")[0])
+    tf_minor_ver = int(tf.__version__.split(".")[1])
+    if(tf_major_ver == 0 and tf_minor_ver < 12): # For tf version <0.12.0
       init = tf.initialize_all_variables()
     else: # For tf version >= 0.12.0
       init = tf.global_variables_initializer()

--- a/dataset/tf-benchmark-googlenet/benchmark-googlenet.py
+++ b/dataset/tf-benchmark-googlenet/benchmark-googlenet.py
@@ -224,7 +224,10 @@ def run_benchmark(openme):
     last_layer = inference(images)
 
     # Build an initialization operation.
-    init = tf.global_variables_initializer()
+    if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+      init = tf.initialize_all_variables()
+    else: # For tf version >= 0.12.0
+      init = tf.global_variables_initializer()
 
     # Start running operations on the Graph.
     sess = tf.Session('')

--- a/dataset/tf-benchmark-googlenet/benchmark-googlenet.py
+++ b/dataset/tf-benchmark-googlenet/benchmark-googlenet.py
@@ -224,7 +224,9 @@ def run_benchmark(openme):
     last_layer = inference(images)
 
     # Build an initialization operation.
-    if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+    tf_major_ver = int(tf.__version__.split(".")[0])
+    tf_minor_ver = int(tf.__version__.split(".")[1])
+    if(tf_major_ver == 0 and tf_minor_ver < 12): # For tf version <0.12.0
       init = tf.initialize_all_variables()
     else: # For tf version >= 0.12.0
       init = tf.global_variables_initializer()


### PR DESCRIPTION
Dear developers,

I found some compatibility problems in your use of TensorFlow APIs, which might lead to crashes in a low version of TensorFlow. And I fix it for you as below:

`tf.global_variables_initializer` is the updated version of `tf.initialize_all_variables`, however, it appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_all_variables` to be safe.

@dsavenko @fanranGit @raduetsya @ens-lg4 @psyhtest 
Hope you could take my advice and look forward to your reply! 😄
