### PR TITLE
Fix benchmarks' names of fields

### DIFF
--- a/program/image-classification-tf-frozen-py/tf_classify_preprocessed.py
+++ b/program/image-classification-tf-frozen-py/tf_classify_preprocessed.py
@@ -190,7 +190,7 @@ def main():
     output_dict = {
         'setup_time_s': setup_time,
         'test_time_s': test_time,
-        'images_load_time_s': load_total_time,
+        'images_load_time_total_s': load_total_time,
         'images_load_time_avg_s': load_avg_time,
         'prediction_time_total_s': classification_total_time,
         'prediction_time_avg_s': classification_avg_time,

--- a/program/image-classification-tf-py/classify.py
+++ b/program/image-classification-tf-py/classify.py
@@ -178,7 +178,7 @@ def main(_):
   openme['test_time_s'] = test_time
   openme['net_create_time_s'] = net_create_time
   openme['weights_load_time_s'] = weights_load_time
-  openme['images_load_time_s'] = load_total_time
+  openme['images_load_time_total_s'] = load_total_time
   openme['images_load_time_avg_s'] = load_avg_time
   openme['prediction_time_total_s'] = class_total_time
   openme['prediction_time_avg_s'] = class_avg_time

--- a/program/image-classification-tflite/benchmark.h
+++ b/program/image-classification-tflite/benchmark.h
@@ -238,7 +238,7 @@ inline void finish_benchmark(const BenchmarkSession& s) {
   // Store metrics
   store_value_f(X_VAR_TIME_SETUP, "setup_time_s", xopenme_get_timer(X_TIMER_SETUP));
   store_value_f(X_VAR_TIME_TEST, "test_time_s", xopenme_get_timer(X_TIMER_TEST));
-  store_value_f(X_VAR_TIME_IMG_LOAD_TOTAL, "images_load_time_s", s.total_load_images_time());
+  store_value_f(X_VAR_TIME_IMG_LOAD_TOTAL, "images_load_time_total_s", s.total_load_images_time());
   store_value_f(X_VAR_TIME_IMG_LOAD_AVG, "images_load_time_avg_s", s.avg_load_images_time());
   store_value_f(X_VAR_TIME_CLASSIFY_TOTAL, "prediction_time_total_s", s.total_prediction_time());
   store_value_f(X_VAR_TIME_CLASSIFY_AVG, "prediction_time_avg_s", s.avg_prediction_time());

--- a/program/object-detection-tf-py/detect.py
+++ b/program/object-detection-tf-py/detect.py
@@ -226,7 +226,7 @@ def detect(category_index):
   OPENME['setup_time_s'] = setup_time
   OPENME['test_time_s'] = test_time
   OPENME['graph_load_time_s'] = graph_load_time
-  OPENME['images_load_time_s'] = load_time_total
+  OPENME['images_load_time_total_s'] = load_time_total
   OPENME['images_load_time_avg_s'] = load_avg_time
   OPENME['detection_time_total_s'] = detect_time_total
   OPENME['detection_time_avg_s'] = detect_avg_time

--- a/program/object-detection-tf-py/postprocess.py
+++ b/program/object-detection-tf-py/postprocess.py
@@ -107,7 +107,7 @@ def ck_postprocess(i):
   print('\nSummary:')
   print('-------------------------------')
   print('Graph loaded in {:.6f}s'.format(OPENME.get('graph_load_time_s', 0)))
-  print('All images loaded in {:.6f}s'.format(OPENME.get('images_load_time_s', 0)))
+  print('All images loaded in {:.6f}s'.format(OPENME.get('images_load_time_total_s', 0)))
   print('All images detected in {:.6f}s'.format(OPENME.get('detection_time_total_s', 0)))
   print('Average detection time: {:.6f}s'.format(OPENME.get('detection_time_avg_s', 0)))
   print('mAP: {}'.format(OPENME['mAP']))

--- a/program/object-detection-tflite/includes/benchmark.h
+++ b/program/object-detection-tflite/includes/benchmark.h
@@ -213,8 +213,8 @@ namespace CK {
         store_value_f(X_VAR_TIME_CLASSIFY_AVG, "prediction_time_avg_s", s.avg_prediction_time());
         store_value_f(X_VAR_TIME_NON_MAX_SUPPRESSION_TOTAL, "non_max_suppression_time_total_s", s.total_non_max_suppression_time());
         store_value_f(X_VAR_TIME_NON_MAX_SUPPRESSION_AVG, "non_max_suppression_time_avg_s", s.avg_non_max_suppression_time());
-        store_value_f(X_VAR_TIME_GRAPH_AVG, "graph_avg_s", s.avg_prediction_time() - s.avg_non_max_suppression_time());
-        store_value_f(X_VAR_TIME_GRAPH_TOTAL, "graph_total_s", s.total_prediction_time() - s.total_non_max_suppression_time());
+        store_value_f(X_VAR_TIME_GRAPH_AVG, "graph_time_avg_s", s.avg_prediction_time() - s.avg_non_max_suppression_time());
+        store_value_f(X_VAR_TIME_GRAPH_TOTAL, "graph_time_total_s", s.total_prediction_time() - s.total_non_max_suppression_time());
 
         // Finish xopenmp
         xopenme_dump_state();

--- a/script/cached-benchmark/postprocess.py
+++ b/script/cached-benchmark/postprocess.py
@@ -180,7 +180,7 @@ def ck_postprocess(i):
 
   setup_time = openme.get('setup_time_s', 0.0)
   test_time = openme.get('test_time_s', 0.0)
-  total_load_images_time = openme.get('images_load_time_s', 0.0)
+  total_load_images_time = openme.get('images_load_time_total_s', 0.0)
   total_prediction_time = openme.get('prediction_time_total_s', 0.0)
   avg_prediction_time = openme.get('prediction_time_avg_s', 0.0)
 


### PR DESCRIPTION
 - rename `graph_avg_s` to `graph_time_avg_s`
 - rename `graph_total_s` to `graph_time_total_s`
 - rename `images_load_time_s` to `images_load_time_total_s`