### PR TITLE
added batch processing

### DIFF
--- a/program/object-detection-tf-py/detect.py
+++ b/program/object-detection-tf-py/detect.py
@@ -75,17 +75,14 @@ def load_pil_images_into_numpy_batch_array(image_list,batch_id,images_ids):
   for img in range(BATCH_SIZE):
     image = PIL.Image.open(os.path.join(IMAGES_DIR, image_list[batch_id*BATCH_SIZE+img]))
     batch_sizes.append(image.size)
-    #image_dim = PIL.Image.new('RGB',(700,700), (0,0,0)) #PIL.Image.BILINEAR)
-
-    image = image.resize((RESIZE_WIDTH_SIZE,RESIZE_HEIGHT_SIZE),PIL.Image.LANCZOS)
+    image = image.resize((RESIZE_WIDTH_SIZE,RESIZE_HEIGHT_SIZE),PIL.Image.BILINEAR)
     image_id = ck_utils.filename_to_id(image_list[batch_id*BATCH_SIZE+img], DATASET_TYPE)
     images_ids.append(image_id)
 
     # Check if not RGB and convert to RGB
     if image.mode != 'RGB':
       image = image.convert('RGB')
-    # Conver to NumPy array
-#    image_dim.paste(image,image.getbbox())
+    # Convert to NumPy array
     img_data = np.array(image.getdata())
     img_data = img_data.astype(np.uint8)
     img_data = img_data.reshape((RESIZE_HEIGHT_SIZE,RESIZE_WIDTH_SIZE,3))
@@ -97,7 +94,7 @@ def load_pil_image_into_numpy_array(image):
   if image.mode != 'RGB':
     image = image.convert('RGB')
 
-  # Conver to NumPy array
+  # Convert to NumPy array
   img_data = np.array(image.getdata())
   img_data = img_data.astype(np.uint8)
 


### PR DESCRIPTION
added the possibility to process batches in the object detection script.
However, batch processing request a fixed image dimension, so I had to include a resizing of the processed images.
This usually introduces a loss of precision in the network.

I changed the IMAGE_COUNT parameter, and it is now divided into 2 variables, BATCH_COUNT and BATCH_SIZE, with the number of processed images being the product of the two.

Other introduced parameter is the ENABLE_BATCH, that is set to false as default, to maintain the previous program ignoring all the resizing and modification for the batch run.

Moreover the resize is done giving 2 parameters, height and width, to support the possibility of resizing to non-squared images. to resize is used the LANCZOS algorithm of the pillow library. The API says that is an high-quality downsizing algorithm.

