### PR TITLE
changed way to load labelmaps to models for object detection

### DIFF
--- a/script/install-package-tensorflowmodel-object-detection/install.sh
+++ b/script/install-package-tensorflowmodel-object-detection/install.sh
@@ -23,12 +23,9 @@ rm -rf tmp
 
 #####################################################################
 echo ""
-#old version, based on the labelmaps from tf api folder
-#echo "Copy label-map file ..."
-#cp -f ${CK_ENV_TENSORFLOW_MODELS_OBJ_DET_DIR}/data/${LABELMAP_FILE} .
+echo "Copy label-map file ..."
 
-#new version, with labelmaps as packages
-cp -f ${CK_ENV_LABELMAP_LABELMAP_FILE} .
+cp -f ${CK_ENV_LABELMAP_FILE} .
 
 
 #####################################################################

--- a/script/install-package-tensorflowmodel-object-detection/install.sh
+++ b/script/install-package-tensorflowmodel-object-detection/install.sh
@@ -23,8 +23,13 @@ rm -rf tmp
 
 #####################################################################
 echo ""
-echo "Copy label-map file ..."
-cp -f ${CK_ENV_TENSORFLOW_MODELS_OBJ_DET_DIR}/data/${LABELMAP_FILE} .
+#old version, based on the labelmaps from tf api folder
+#echo "Copy label-map file ..."
+#cp -f ${CK_ENV_TENSORFLOW_MODELS_OBJ_DET_DIR}/data/${LABELMAP_FILE} .
+
+#new version, with labelmaps as packages
+cp -f ${CK_ENV_LABELMAP_LABELMAP_FILE} .
+
 
 #####################################################################
 echo ""


### PR DESCRIPTION
small change for the install.sh used to install object detection models.
it allows to use labelmap files from ck-object-detection packages instead of relying on tensorflow API.
This is needed to have the full kitti labelmap (with all the classes) that is not available in tensorflow API.
